### PR TITLE
Allow converting from Error to io::Error

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -54,6 +54,12 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<Error> for io::Error {
+    fn from(err: Error) -> io::Error {
+        io::Error::new(io::ErrorKind::Other, err)
+    }
+}
+
 
 // Result
 


### PR DESCRIPTION
Useful when integrating with other futures/tokio libraries