### PR TITLE
use 0.9.* version of openssl

### DIFF
--- a/api-test/Cargo.toml
+++ b/api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls-api-test"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 description = "TLS API without implementation"
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["tls"]
 travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch = "master" }
 
 [dependencies]
-tls-api    = { version = "0.1.12", path = "../api" }
+tls-api    = { version = "0.1.13", path = "../api" }
 log        = "0.*"
 env_logger = "0.*"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls-api"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 description = "TLS API without implementation"
 license = "MIT/Apache-2.0"

--- a/impl-native-tls/Cargo.toml
+++ b/impl-native-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls-api-native-tls"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 description = "TLS API implementation over native-tls crate"
 license = "MIT/Apache-2.0"
@@ -12,7 +12,7 @@ travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch
 
 [dependencies]
 native-tls = "0.*"
-tls-api = { version = "0.1.12", path = "../api" }
+tls-api = { version = "0.1.13", path = "../api" }
 
 [dev-dependencies]
-tls-api-test = { version = "0.1.12", path = "../api-test" }
+tls-api-test = { version = "0.1.13", path = "../api-test" }

--- a/impl-openssl/Cargo.toml
+++ b/impl-openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls-api-openssl"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 description = "TLS API implementation over openssl crate"
 license = "MIT/Apache-2.0"
@@ -14,8 +14,8 @@ travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch
 [dependencies]
 # To implement OpenSSL version check in build.rs
 openssl-sys = { version = "0.*" }
-openssl     = { version = "0.*", features = ["v102", "v110"] }
-tls-api     = { version = "0.1.12", path = "../api" }
+openssl     = { version = "0.9.*", features = ["v102", "v110"] }
+tls-api     = { version = "0.1.13", path = "../api" }
 
 [dev-dependencies]
-tls-api-test = { version = "0.1.12", path = "../api-test" }
+tls-api-test = { version = "0.1.13", path = "../api-test" }

--- a/impl-rustls/Cargo.toml
+++ b/impl-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls-api-rustls"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 description = "TLS API implementation over rustls crate"
 license = "MIT/Apache-2.0"
@@ -12,9 +12,9 @@ travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch
 
 [dependencies]
 rustls = { version = "0.11", features = ["dangerous_configuration"] }
-tls-api = { version = "0.1.12", path = "../api" }
+tls-api = { version = "0.1.13", path = "../api" }
 webpki       = "0.17"
 webpki-roots = "0.13"
 
 [dev-dependencies]
-tls-api-test = { version = "0.1.12", path = "../api-test" }
+tls-api-test = { version = "0.1.13", path = "../api-test" }

--- a/impl-stub/Cargo.toml
+++ b/impl-stub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls-api-stub"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 description = "TLS API implementation that returns error on any operation"
 license = "MIT/Apache-2.0"
@@ -11,8 +11,8 @@ keywords = ["tls"]
 travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch = "master" }
 
 [dependencies]
-tls-api = { version = "0.1.12", path = "../api" }
+tls-api = { version = "0.1.13", path = "../api" }
 void    = "1"
 
 [dev-dependencies]
-tls-api-test = { version = "0.1.12", path = "../api-test" }
+tls-api-test = { version = "0.1.13", path = "../api-test" }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 
 [dependencies]
-tls-api-test       = { version = "0.1.12", path = "../api-test" }
-tls-api-openssl    = { version = "0.1.12", path = "../impl-openssl" }
-tls-api-rustls     = { version = "0.1.12", path = "../impl-rustls" }
-tls-api-native-tls = { version = "0.1.12", path = "../impl-native-tls" }
+tls-api-test       = { version = "0.1.13", path = "../api-test" }
+tls-api-openssl    = { version = "0.1.13", path = "../impl-openssl" }
+tls-api-rustls     = { version = "0.1.13", path = "../impl-rustls" }
+tls-api-native-tls = { version = "0.1.13", path = "../impl-native-tls" }

--- a/tokio-tls-api/Cargo.toml
+++ b/tokio-tls-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-tls-api"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Carl Lerche <me@carllerche.com>",
            "Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["asynchronous", "network-programming"]
 
 [dependencies]
 futures = "0.*"
-tls-api = { version = "0.1.12", path = "../api" }
+tls-api = { version = "0.1.13", path = "../api" }
 tokio-core = "0.*"
 tokio-io = "0.1"
 tokio-proto = { version = "0.1", optional = true }
@@ -22,7 +22,7 @@ tokio-proto = { version = "0.1", optional = true }
 [dev-dependencies]
 env_logger = { version = "0.3", default-features = false }
 cfg-if = "0.1"
-tls-api-native-tls = { version = "0.1.12", path = "../impl-native-tls" }
+tls-api-native-tls = { version = "0.1.13", path = "../impl-native-tls" }
 
 [target.'cfg(all(not(target_os = "macos"), not(windows), not(target_os = "ios")))'.dev-dependencies]
 openssl = "0.9"

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-version="0.1.12"
+version="0.1.13"
 
 sed -e '/0\.0\.0/ ! s,^version = .*,version = "'$version'",' -i '' \
     */Cargo.toml


### PR DESCRIPTION
I propose setting 0.9.* version of openssl and publish a minor version bump. As well as the rustls fix in the other PR please. 

Then bump rust-tls-api to 0.2.0 to reflect openssl 0.10 api changes. I can send a pull request for that as well. 