### PR TITLE
Pin futures related deps to `0.1.*` in `tokio-tls-api`.

### DIFF
--- a/tokio-tls-api/Cargo.toml
+++ b/tokio-tls-api/Cargo.toml
@@ -13,11 +13,11 @@ for nonblocking I/O streams.
 categories = ["asynchronous", "network-programming"]
 
 [dependencies]
-futures = "0.*"
+futures = "0.1.*"
 tls-api = { version = "0.1.14", path = "../api" }
-tokio-core = "0.*"
-tokio-io = "0.1"
-tokio-proto = { version = "0.1", optional = true }
+tokio-core = "0.1.*"
+tokio-io = "0.1.*"
+tokio-proto = { version = "0.1.*", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }


### PR DESCRIPTION
I've used this update, along with my updates in [rust-http2](https://github.com/stepancheg/rust-http2/pull/25) & [grpc-rust](https://github.com/stepancheg/grpc-rust/pull/113), integrated them into my create, and things appear to be back in order.