### PR TITLE
Remove deprecated tokio-core.

### DIFF
--- a/tokio-tls-api-examples/Cargo.toml
+++ b/tokio-tls-api-examples/Cargo.toml
@@ -14,8 +14,7 @@ categories = ["asynchronous", "network-programming"]
 [dependencies]
 futures = "0.1"
 tls-api = { version = "0.1.19", path = "../api" }
-tokio-core = "0.1"
-tokio-io = "0.1"
+tokio-io = "0.1.6"
 tokio-proto = { version = "0.1", optional = true }
 tokio-tls-api = { version = "0.1.19", path = "../tokio-tls-api" }
 
@@ -23,6 +22,8 @@ tokio-tls-api = { version = "0.1.19", path = "../tokio-tls-api" }
 env_logger = { version = "0.5", default-features = false }
 cfg-if = "0.1"
 tls-api-native-tls = { version = "0.1.19", path = "../impl-native-tls" }
+tokio-tcp = "0.1.0"
+tokio = "0.1.6"
 
 [target.'cfg(all(not(target_os = "macos"), not(windows), not(target_os = "ios")))'.dev-dependencies]
 openssl = "0.9"

--- a/tokio-tls-api/Cargo.toml
+++ b/tokio-tls-api/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["asynchronous", "network-programming"]
 [dependencies]
 futures = "0.1"
 tls-api = { version = "0.1.19", path = "../api" }
-tokio-core = "0.1"
-tokio-io = "0.1"
+tokio-io = "0.1.6"
 tokio-proto = { version = "0.1", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }
 cfg-if = "0.1"
+tokio-tcp = "0.1.0"
 
 [target.'cfg(all(not(target_os = "macos"), not(windows), not(target_os = "ios")))'.dev-dependencies]
 openssl = "0.9"

--- a/tokio-tls-api/src/lib.rs
+++ b/tokio-tls-api/src/lib.rs
@@ -22,7 +22,6 @@
 extern crate futures;
 extern crate tls_api;
 #[macro_use]
-extern crate tokio_core;
 extern crate tokio_io;
 
 use std::fmt;
@@ -30,8 +29,6 @@ use std::io::{self, Read, Write};
 
 use futures::{Poll, Future, Async};
 use tls_api::{HandshakeError, Error, TlsConnector, TlsAcceptor};
-#[allow(deprecated)]
-use tokio_core::io::Io;
 use tokio_io::{AsyncRead, AsyncWrite};
 
 pub mod proto;
@@ -92,10 +89,6 @@ impl<S: Read + Write> Write for TlsStream<S> {
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
     }
-}
-
-#[allow(deprecated)]
-impl<S: Io> Io for TlsStream<S> {
 }
 
 impl<S: AsyncRead + AsyncWrite> AsyncRead for TlsStream<S> {

--- a/tokio-tls-api/tests/bad.rs
+++ b/tokio-tls-api/tests/bad.rs
@@ -1,8 +1,8 @@
 extern crate env_logger;
 extern crate futures;
 extern crate tls_api;
-extern crate tokio_core;
 extern crate tokio_tls_api;
+extern crate tokio_tcp;
 
 #[macro_use]
 extern crate cfg_if;
@@ -12,8 +12,7 @@ use std::net::ToSocketAddrs;
 
 use futures::Future;
 use tls_api::TlsConnector;
-use tokio_core::net::TcpStream;
-use tokio_core::reactor::Core;
+use tokio_tcp::TcpStream;
 
 /*
 macro_rules! t {

--- a/tokio-tls-api/tests/smoke.rs
+++ b/tokio-tls-api/tests/smoke.rs
@@ -1,7 +1,6 @@
 extern crate env_logger;
 extern crate futures;
 extern crate tls_api;
-extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_tls_api;
 


### PR DESCRIPTION
Fixes #20
Uses `CurrentThead` executor in example instead of reactor.