### PR TITLE
Fix code block formatting

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -99,9 +99,9 @@ pub trait TlsStreamImpl<S> : io::Read + io::Write + fmt::Debug + Send + Sync + '
 /// trait TlsConnector {
 ///     type <S> TlsStream<S> : TlsStreamImpl;
 /// }
+/// ```
 ///
 /// So `TlsStream` is actually a box to concrete TLS implementation.
-/// ```
 #[derive(Debug)]
 pub struct TlsStream<S>(Box<TlsStreamImpl<S> + 'static>);
 


### PR DESCRIPTION
When running `cargo doc`, I see this error:

```
cargo doc -p tls-api
 Documenting cfg-if v0.1.6
    Checking cfg-if v0.1.6
    Checking log v0.4.6
 Documenting log v0.4.6
 Documenting tls-api v0.1.19 (/home/rkd/src/rust-tls-api/api)
warning: Backing out of syntax highlighting
  |
  = note: You probably did not intend to render this as a rust code-block

error: unknown start of token: `
 --> <stdin>:5:4
  |
5 | So `TlsStream` is actually a box to concrete TLS implementation.
  |    ^
help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it is not
  |
5 | So 'TlsStream` is actually a box to concrete TLS implementation.
  |    ^

    Finished dev [unoptimized + debuginfo] target(s) in 3.56s
```

This is because a code block wasn't closed correctly - this fixes it.