### PR TITLE
tls-api: update native-tls to 0.2

### DIFF
--- a/impl-native-tls/Cargo.toml
+++ b/impl-native-tls/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["tls"]
 travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch = "master" }
 
 [dependencies]
-native-tls = "0.1"
+native-tls = "0.2"
 tls-api = { path = "../api", version = "=0.1.22" }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR updates native-tls to 0.2, fixing issue https://github.com/stepancheg/rust-tls-api/issues/26

Unit tests pass after the API upgrade