### PR TITLE
Implemented selectable async runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ rust:
 script:
   - rustc --version
   - RUST_BACKTRACE=1 cargo test --all
+  - 'for k in api api-test impl-native-tls impl-openssl impl-rustls impl-stub examples interop ; do sh -e -c "cd $k; echo Build async-stc crate $k ; RUST_BACKTRACE=1 cargo test --no-default-features --features runtime-async-std"; done'
+  # Once package-features is stable you can change the above to:
+  #- RUST_BACKTRACE=1 cargo test --all --no-default-features --features runtime-async-std
+  # You can test it on nightly: cargo +nightly test -Z package-features --all --no-default-features --features runtime-async-std
   # `cargo test --benches` and `#[feature(test)]` only works on nightly
   #- test "$TRAVIS_RUST_VERSION" != "nightly" || RUST_BACKTRACE=1 cargo test --benches
 

--- a/api-test/Cargo.toml
+++ b/api-test/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch = "master" }
 
 [dependencies]
-tls-api = { path = "../api", version = "=0.5.0-pre" }
+tls-api = { path = "../api", version = "=0.5.0-pre", default-features = false }
 log        = "0.4"
 env_logger = "0.5"
 
@@ -20,4 +20,10 @@ pem        = "0.6.*"
 webpki     = "0.21.2"
 untrusted  = "0.6.*"
 
-tokio = { version = "~0.2.6", features = ["tcp", "io-util", "dns"] }
+tokio = { version = "~0.2.6", features = ["tcp", "io-util", "dns"], optional = true }
+async-std = { version = "1.6.0", features = ["attributes"], optional = true }
+
+[features]
+default = ["runtime-tokio"]
+runtime-async-std = ["async-std", "tls-api/runtime-async-std"]
+runtime-tokio = ["tokio", "tls-api/runtime-tokio"]

--- a/api-test/src/lib.rs
+++ b/api-test/src/lib.rs
@@ -15,14 +15,27 @@ use tls_api::TlsAcceptorBuilder;
 use tls_api::TlsConnector;
 use tls_api::TlsConnectorBuilder;
 use tls_api::TlsStream;
+use tls_api::runtime::{AsyncReadExt, AsyncWriteExt};
 
 use std::net::ToSocketAddrs;
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWriteExt;
-use tokio::net::TcpListener;
-use tokio::net::TcpStream;
 
+#[cfg(feature = "runtime-tokio")]
+use std::future::Future;
+#[cfg(feature = "runtime-tokio")]
+use tokio::net::{TcpListener, TcpStream};
+#[cfg(feature = "runtime-tokio")]
 use tokio::runtime::Runtime;
+#[cfg(feature = "runtime-async-std")]
+use async_std::task::block_on;
+#[cfg(feature = "runtime-async-std")]
+use async_std::net::{TcpStream, TcpListener};
+
+#[cfg(feature = "runtime-tokio")]
+pub fn block_on<F, T>(future: F) -> T
+    where F: Future<Output = T>,
+{
+    t!(Runtime::new()).block_on(future)
+}
 
 async fn test_google_impl<C: TlsConnector>() {
     drop(env_logger::try_init());
@@ -50,7 +63,7 @@ async fn test_google_impl<C: TlsConnector>() {
 }
 
 pub fn test_google<C: TlsConnector>() {
-    t!(Runtime::new()).block_on(test_google_impl::<C>())
+    block_on(test_google_impl::<C>())
 }
 
 async fn connect_bad_hostname_impl<C: TlsConnector>() -> tls_api::Error {
@@ -68,7 +81,7 @@ async fn connect_bad_hostname_impl<C: TlsConnector>() -> tls_api::Error {
 }
 
 pub fn connect_bad_hostname<C: TlsConnector>() -> tls_api::Error {
-    t!(Runtime::new()).block_on(connect_bad_hostname_impl::<C>())
+    block_on(connect_bad_hostname_impl::<C>())
 }
 
 async fn connect_bad_hostname_ignored_impl<C: TlsConnector>() {
@@ -88,7 +101,7 @@ async fn connect_bad_hostname_ignored_impl<C: TlsConnector>() {
 }
 
 pub fn connect_bad_hostname_ignored<C: TlsConnector>() {
-    t!(Runtime::new()).block_on(connect_bad_hostname_ignored_impl::<C>())
+    block_on(connect_bad_hostname_ignored_impl::<C>())
 }
 
 pub struct RsaPrivateKey(pub Vec<u8>);
@@ -181,7 +194,7 @@ where
     let acceptor = new_acceptor::<A, _>(acceptor);
 
     let acceptor: A = acceptor.build().expect("acceptor build");
-
+    #[allow(unused_mut)]
     let mut listener = t!(TcpListener::bind((BIND_HOST, 0)).await);
     let port = listener.local_addr().expect("local_addr").port();
 
@@ -196,7 +209,7 @@ where
 
             t!(socket.write_all(b"world").await);
         };
-        t!(Runtime::new()).block_on(future);
+        block_on(future);
     });
 
     let socket = t!(TcpStream::connect((BIND_HOST, port)).await);
@@ -219,7 +232,7 @@ where
     A: TlsAcceptor,
     F: FnOnce(&Pkcs12, &CertificatesAndKey) -> A::Builder,
 {
-    t!(Runtime::new()).block_on(server_impl::<C, A, F>(acceptor))
+    block_on(server_impl::<C, A, F>(acceptor))
 }
 
 async fn alpn_impl<C, A, F>(acceptor: F)
@@ -248,6 +261,7 @@ where
 
     let acceptor: A = t!(acceptor.build());
 
+    #[allow(unused_mut)]
     let mut listener = t!(TcpListener::bind((BIND_HOST, 0)).await);
     let port = listener.local_addr().expect("local_addr").port();
 
@@ -264,7 +278,7 @@ where
 
             t!(socket.write_all(b"world").await);
         };
-        t!(Runtime::new()).block_on(f);
+        block_on(f);
     });
 
     let socket = t!(TcpStream::connect((BIND_HOST, port)).await);
@@ -294,5 +308,5 @@ where
     A: TlsAcceptor,
     F: FnOnce(&Pkcs12, &CertificatesAndKey) -> A::Builder,
 {
-    t!(Runtime::new()).block_on(alpn_impl::<C, A, F>(acceptor))
+    block_on(alpn_impl::<C, A, F>(acceptor))
 }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,4 +15,10 @@ travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch
 [dependencies]
 log        = "0.4"
 
-tokio = { version = "~0.2.6", features = [] }
+futures-util = { version = "0.3.1", features = ["io"], optional = true }
+tokio = { version = "~0.2.6", features = ["io-util"], optional = true }
+
+
+[features]
+runtime-async-std = ["futures-util"]
+runtime-tokio = ["tokio"]

--- a/api/src/async_as_sync.rs
+++ b/api/src/async_as_sync.rs
@@ -8,8 +8,9 @@ use std::ptr;
 use std::task::Context;
 use std::task::Poll;
 use std::{error, fmt, io};
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
+
+use crate::runtime::AsyncRead;
+use crate::runtime::AsyncWrite;
 
 /// Async IO object as sync IO.
 ///

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -8,9 +8,11 @@ use std::pin::Pin;
 use std::result;
 use std::task::Context;
 use std::task::Poll;
-use tokio::prelude::*;
 
 pub mod async_as_sync;
+pub mod runtime;
+
+use runtime::{AsyncRead, AsyncWrite};
 
 // Error
 
@@ -165,8 +167,14 @@ impl<S> AsyncWrite for TlsStream<S> {
         Pin::new(&mut self.0).poll_flush(cx)
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_shutdown(cx)
+    #[cfg(feature = "runtime-async-std")]
+    fn poll_close(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_close(ctx)
+    }
+
+    #[cfg(feature = "runtime-tokio")]
+    fn poll_shutdown(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_shutdown(ctx)
     }
 }
 

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "runtime-async-std")]
+pub use futures_util::io::{AsyncRead, AsyncWrite};
+
+#[cfg(feature = "runtime-async-std")]
+#[allow(unused_imports)]
+pub use futures_util::io::{AsyncReadExt, AsyncWriteExt};
+
+#[cfg(feature = "runtime-tokio")]
+pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,13 +13,19 @@ publish = false
 edition = "2018"
 
 [dependencies]
-tokio = { version = "~0.2.6", features = ["full"] }
-tls-api = { path = "../api" }
+tls-api = { path = "../api", default-features = false }
+tokio = { version = "~0.2.6", features = ["full"], optional = true }
+async-std = { version = "1.6.0", features = ["attributes"], optional = true }
+tls-api-native-tls = { path = "../impl-native-tls", default-features = false }
+
+[features]
+default = ["runtime-tokio"]
+runtime-async-std = ["async-std", "tls-api/runtime-async-std", "tls-api-native-tls/runtime-async-std"]
+runtime-tokio = ["tokio", "tls-api/runtime-tokio", "tls-api-native-tls/runtime-tokio"]
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }
 cfg-if = "0.1"
-tls-api-native-tls = { path = "../impl-native-tls" }
 tokio = { version = "~0.2.6", features = ["net"] }
 
 [target.'cfg(all(not(target_os = "macos"), not(windows), not(target_os = "ios")))'.dev-dependencies]

--- a/examples/examples/download-rust-lang.rs
+++ b/examples/examples/download-rust-lang.rs
@@ -1,12 +1,20 @@
 use std::net::ToSocketAddrs;
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWriteExt;
+use tls_api::runtime::AsyncReadExt;
+use tls_api::runtime::AsyncWriteExt;
 
 use tls_api::TlsConnector;
 use tls_api::TlsConnectorBuilder;
-use tokio::net::TcpStream;
 
-#[tokio::main]
+#[cfg(feature = "runtime-tokio")]
+use tokio::main;
+#[cfg(feature = "runtime-tokio")]
+use tokio::net::TcpStream;
+#[cfg(feature = "runtime-async-std")]
+use async_std::main;
+#[cfg(feature = "runtime-async-std")]
+use async_std::net::TcpStream;
+
+#[crate::main]
 async fn main() {
     let addr = "www.rust-lang.org:443"
         .to_socket_addrs()

--- a/impl-native-tls/Cargo.toml
+++ b/impl-native-tls/Cargo.toml
@@ -13,9 +13,18 @@ travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch
 
 [dependencies]
 native-tls = "0.2"
-tls-api = { path = "../api", version = "=0.5.0-pre" }
+tls-api = { path = "../api", version = "=0.5.0-pre", default-features = false }
 
-tokio = { version = "~0.2.6", features = [] }
+tokio = { version = "~0.2.6", features = [], optional = true }
+async-std = { version = "1.6.0", features = ["attributes"], optional = true }
+
+# this is needed until package-features is stabelized (issue #5364)
+tls-api-test = { path = "../api-test", version = "=0.5.0-pre", default-features = false }
+
+[features]
+default = ["runtime-tokio"]
+runtime-async-std = ["async-std", "tls-api/runtime-async-std", "tls-api-test/runtime-async-std"]
+runtime-tokio = ["tokio", "tls-api/runtime-tokio", "tls-api-test/runtime-tokio"]
 
 [dev-dependencies]
-tls-api-test = { path = "../api-test", version = "=0.5.0-pre" }
+tls-api-test = { path = "../api-test", version = "=0.5.0-pre", default-features = false }

--- a/impl-native-tls/src/handshake.rs
+++ b/impl-native-tls/src/handshake.rs
@@ -9,8 +9,8 @@ use std::result;
 use std::task::Context;
 use std::task::Poll;
 use tls_api::async_as_sync::AsyncIoAsSyncIo;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
+use tls_api::runtime::AsyncRead;
+use tls_api::runtime::AsyncWrite;
 
 pub(crate) enum HandshakeFuture<F, S: Unpin> {
     Initial(F, AsyncIoAsSyncIo<S>),

--- a/impl-native-tls/src/lib.rs
+++ b/impl-native-tls/src/lib.rs
@@ -12,8 +12,8 @@ use tls_api::async_as_sync::AsyncIoAsSyncIo;
 use tls_api::async_as_sync::AsyncIoAsSyncIoWrapper;
 use tls_api::Error;
 use tls_api::Result;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
+use tls_api::runtime::AsyncRead;
+use tls_api::runtime::AsyncWrite;
 
 mod handshake;
 
@@ -107,7 +107,14 @@ impl<S: Unpin + fmt::Debug + AsyncRead + AsyncWrite + Sync + Send> AsyncWrite fo
             .with_context_sync_to_async(cx, |stream| stream.0.flush())
     }
 
+    #[cfg(feature = "runtime-tokio")]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut()
+            .with_context_sync_to_async(cx, |stream| stream.0.shutdown())
+    }
+
+    #[cfg(feature = "runtime-async-std")]
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.get_mut()
             .with_context_sync_to_async(cx, |stream| stream.0.shutdown())
     }

--- a/impl-openssl/Cargo.toml
+++ b/impl-openssl/Cargo.toml
@@ -16,8 +16,17 @@ travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch
 # To implement OpenSSL version check in build.rs
 openssl-sys = { version = "0.9.43" }
 openssl     = { version = "0.10.20", features = ["v102", "v110"] }
-tokio = { version = "~0.2.6", features = [] }
-tls-api = { path = "../api", version = "=0.5.0-pre" }
+tls-api = { path = "../api", version = "=0.5.0-pre", default-features = false }
+tokio = { version = "~0.2.6", features = [], optional = true }
+async-std = { version = "1.6.0", features = ["attributes"], optional = true }
+
+# this is needed until package-features is stabelized (issue #5364)
+tls-api-test = { path = "../api-test", version = "=0.5.0-pre", default-features = false }
+
+[features]
+default = ["runtime-tokio"]
+runtime-async-std = ["async-std", "tls-api/runtime-async-std", "tls-api-test/runtime-async-std"]
+runtime-tokio = ["tokio", "tls-api/runtime-tokio", "tls-api-test/runtime-tokio"]
 
 [dev-dependencies]
-tls-api-test = { path = "../api-test", version = "=0.5.0-pre" }
+tls-api-test = { path = "../api-test", version = "=0.5.0-pre", default-features = false }

--- a/impl-openssl/src/handshake.rs
+++ b/impl-openssl/src/handshake.rs
@@ -9,8 +9,8 @@ use std::result;
 use std::task::Context;
 use std::task::Poll;
 use tls_api::async_as_sync::AsyncIoAsSyncIo;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
+use tls_api::runtime::AsyncRead;
+use tls_api::runtime::AsyncWrite;
 
 pub(crate) enum HandshakeFuture<F, S: Unpin> {
     Initial(F, AsyncIoAsSyncIo<S>),

--- a/impl-openssl/src/lib.rs
+++ b/impl-openssl/src/lib.rs
@@ -14,8 +14,8 @@ use tls_api::async_as_sync::AsyncIoAsSyncIo;
 use tls_api::async_as_sync::AsyncIoAsSyncIoWrapper;
 use tls_api::Error;
 use tls_api::Result;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
+use tls_api::runtime::AsyncRead;
+use tls_api::runtime::AsyncWrite;
 
 mod handshake;
 
@@ -156,6 +156,7 @@ impl<S: AsyncRead + AsyncWrite + fmt::Debug + Unpin> AsyncWrite for TlsStream<S>
         self.with_context_sync_to_async(cx, |stream| stream.0.flush())
     }
 
+    #[cfg(feature = "runtime-tokio")]
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.with_context_sync_to_async(cx, |stream| match stream.0.shutdown() {
             Ok(_) => Ok(()),
@@ -163,6 +164,16 @@ impl<S: AsyncRead + AsyncWrite + fmt::Debug + Unpin> AsyncWrite for TlsStream<S>
             Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
         })
     }
+
+    #[cfg(feature = "runtime-async-std")]
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.with_context_sync_to_async(cx, |stream| match stream.0.shutdown() {
+            Ok(_) => Ok(()),
+            Err(ref e) if e.code() == openssl::ssl::ErrorCode::ZERO_RETURN => Ok(()),
+            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+        })
+    }
+
 }
 
 impl<S: AsyncRead + AsyncWrite + fmt::Debug + Unpin + Send + Sync + 'static>

--- a/impl-rustls/Cargo.toml
+++ b/impl-rustls/Cargo.toml
@@ -13,10 +13,19 @@ travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch
 
 [dependencies]
 rustls = { version = "0.17.0", features = ["dangerous_configuration"] }
-tokio = { version = "~0.2.6", features = [] }
-tls-api = { path = "../api", version = "=0.5.0-pre" }
+tls-api = { path = "../api", version = "=0.5.0-pre", default-features = false }
 webpki       = "0.21.2"
 webpki-roots = "0.19.0"
+tokio = { version = "~0.2.6", features = [], optional = true }
+async-std = { version = "1.6.0", features = ["attributes"], optional = true }
+
+# this is needed until package-features is stabelized (issue #5364)
+tls-api-test = { path = "../api-test", version = "=0.5.0-pre", default-features = false }
+
+[features]
+default = ["runtime-tokio"]
+runtime-async-std = ["async-std", "tls-api/runtime-async-std", "tls-api-test/runtime-async-std"]
+runtime-tokio = ["tokio", "tls-api/runtime-tokio", "tls-api-test/runtime-tokio"]
 
 [dev-dependencies]
-tls-api-test = { path = "../api-test", version = "=0.5.0-pre" }
+tls-api-test = { path = "../api-test", version = "=0.5.0-pre", default-features = false }

--- a/impl-rustls/src/handshake.rs
+++ b/impl-rustls/src/handshake.rs
@@ -5,8 +5,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{fmt, io, mem};
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
+use tls_api::runtime::AsyncRead;
+use tls_api::runtime::AsyncWrite;
 
 pub(crate) enum HandshakeFuture<S, T>
 where

--- a/impl-rustls/src/lib.rs
+++ b/impl-rustls/src/lib.rs
@@ -16,8 +16,8 @@ use tls_api::async_as_sync::AsyncIoAsSyncIo;
 use tls_api::async_as_sync::AsyncIoAsSyncIoWrapper;
 use tls_api::Error;
 use tls_api::Result;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
+use tls_api::runtime::AsyncRead;
+use tls_api::runtime::AsyncWrite;
 use webpki::DNSNameRef;
 
 mod handshake;
@@ -124,7 +124,13 @@ where
         })
     }
 
+    #[cfg(feature = "runtime-tokio")]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.poll_flush(cx)
+    }
+
+    #[cfg(feature = "runtime-async-std")]
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.poll_flush(cx)
     }
 }

--- a/impl-stub/Cargo.toml
+++ b/impl-stub/Cargo.toml
@@ -12,9 +12,16 @@ edition = "2018"
 travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch = "master" }
 
 [dependencies]
-tokio = { version = "~0.2.6", features = [] }
 void    = "1"
-tls-api = { path = "../api", version = "=0.5.0-pre" }
+tls-api = { path = "../api", version = "=0.5.0-pre", default-features = false }
+
+# this is needed until package-features is stabelized (issue #5364)
+tls-api-test = { path = "../api-test", version = "=0.5.0-pre", default-features = false }
+
+[features]
+default = ["runtime-tokio"]
+runtime-async-std = ["tls-api/runtime-async-std", "tls-api-test/runtime-async-std"]
+runtime-tokio = ["tls-api/runtime-tokio", "tls-api-test/runtime-tokio"]
 
 [dev-dependencies]
-tls-api-test = { path = "../api-test", version = "=0.5.0-pre" }
+tls-api-test = { path = "../api-test", version = "=0.5.0-pre", default-features = false }

--- a/impl-stub/src/lib.rs
+++ b/impl-stub/src/lib.rs
@@ -19,8 +19,8 @@ use std::future::Future;
 use std::pin::Pin;
 use tls_api::Result;
 use tls_api::TlsStream;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
+use tls_api::runtime::AsyncRead;
+use tls_api::runtime::AsyncWrite;
 
 pub struct Pkcs12(Void);
 

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -6,8 +6,12 @@ publish = false
 edition = "2018"
 description = "Test different implementations compatible with each other"
 
+[features]
+runtime-async-std = ["tls-api-test/runtime-async-std", "tls-api-openssl/runtime-async-std", "tls-api-rustls/runtime-async-std", "tls-api-native-tls/runtime-async-std"]
+runtime-tokio = ["tls-api-test/runtime-tokio", "tls-api-openssl/runtime-tokio", "tls-api-rustls/runtime-tokio", "tls-api-native-tls/runtime-tokio"]
+
 [dependencies]
-tls-api-test       = { path = "../api-test" }
-tls-api-openssl    = { path = "../impl-openssl" }
-tls-api-rustls     = { path = "../impl-rustls" }
-tls-api-native-tls = { path = "../impl-native-tls" }
+tls-api-test       = { path = "../api-test", default-features = false }
+tls-api-openssl    = { path = "../impl-openssl", default-features = false }
+tls-api-rustls     = { path = "../impl-rustls", default-features = false }
+tls-api-native-tls = { path = "../impl-native-tls", default-features = false }


### PR DESCRIPTION
Right now there is a split in the community between `tokio` and
`async-std` which use different definitions of the `AsyncRead` and
`AsyncWrite` traits. Inspired by the `async-native-tls` crate I have
implemented support for both runtimes selectable via features.

To keep backwards compatibility the default runtime is still `tokio`.