### PR TITLE
use tempfile instead of tempdir

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch
 log        = "0.4"
 pem        = "0.8.3"
 webpki     = "0.22.0"
-tempdir    = "0.3.7"
+tempfile   = "3.3.0"
 void       = "1.0.2"
 anyhow     = "1.0.44"
 thiserror  = "1.0.30"

--- a/api/src/openssl.rs
+++ b/api/src/openssl.rs
@@ -2,9 +2,14 @@ use std::fs;
 use std::process::Command;
 use std::process::Stdio;
 
+use tempfile::Builder as TempBuilder;
+
 /// Convert DER certificate to PKCS #12 using openssl command.
 pub(crate) fn der_to_pkcs12(cert: &[u8], key: &[u8]) -> anyhow::Result<(Vec<u8>, String)> {
-    let temp_dir = tempdir::TempDir::new("tls-api-der-to-pkcs12").unwrap();
+    let temp_dir = TempBuilder::new()
+        .prefix("tls-api-der-to-pkcs12")
+        .tempdir()
+        .unwrap();
 
     let cert_file = temp_dir.path().join("cert.pem");
     let pkcs12_file = temp_dir.path().join("cert.pkcs12");
@@ -50,7 +55,10 @@ pub(crate) fn der_to_pkcs12(cert: &[u8], key: &[u8]) -> anyhow::Result<(Vec<u8>,
 
 /// PKCS #12 certificate to DER using openssl command.
 pub(crate) fn pkcs12_to_der(pkcs12: &[u8], passphrase: &str) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
-    let temp_dir = tempdir::TempDir::new("tls-api-der-to-pkcs12").unwrap();
+    let temp_dir = TempBuilder::new()
+        .prefix("tls-api-der-to-pkcs12")
+        .tempdir()
+        .unwrap();
 
     let cert_pem_file = temp_dir.path().join("cert.pem");
     let pkcs12_file = temp_dir.path().join("cert.pkcs12");

--- a/test-cert-gen/Cargo.toml
+++ b/test-cert-gen/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT/Apache-2.0"
 bench = false
 
 [dependencies]
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 pem = "0.8.3"

--- a/test-cert-gen/src/lib.rs
+++ b/test-cert-gen/src/lib.rs
@@ -10,6 +10,8 @@ use std::process::Stdio;
 use std::ptr;
 use std::sync::Once;
 
+use tempfile::Builder as TempBuilder;
+
 mod cert;
 
 pub use cert::pem_to_cert_key_pair;
@@ -54,7 +56,10 @@ pub struct Keys {
 }
 
 fn gen_root_ca() -> CertAndPrivateKey {
-    let temp_dir = tempdir::TempDir::new("rust-test-cert-gen-gen-root-ca").unwrap();
+    let temp_dir = TempBuilder::new()
+        .prefix("rust-test-cert-gen-gen-root-ca")
+        .tempdir()
+        .unwrap();
 
     let config = temp_dir.path().join("openssl.config");
     let keyfile = temp_dir.path().join("root_ca.key");
@@ -118,7 +123,7 @@ fn gen_root_ca() -> CertAndPrivateKey {
 fn gen_cert_for_domain(domain: &str, ca: &CertAndPrivateKey) -> CertAndPrivateKey {
     assert!(!domain.is_empty());
 
-    let temp_dir = tempdir::TempDir::new("pem-to-der").unwrap();
+    let temp_dir = TempBuilder::new().prefix("pem-to-der").tempdir().unwrap();
     let privkey_pem_path = temp_dir.path().join("privkey.pem");
     let csr = temp_dir.path().join("csr.pem");
     let ca_pem = temp_dir.path().join("ca.pem");
@@ -291,7 +296,10 @@ fn _pkcs12_to_pem(pkcs12: &Pkcs12, passin: &str) -> String {
 }
 
 fn pem_to_pkcs12(cert: &CertAndPrivateKey, pass: &str) -> Pkcs12 {
-    let temp_dir = tempdir::TempDir::new("pem-to-pkcs12").unwrap();
+    let temp_dir = TempBuilder::new()
+        .prefix("pem-to-pkcs12")
+        .tempdir()
+        .unwrap();
 
     let certfile = temp_dir.path().join("cert.pem");
     let keyfile = temp_dir.path().join("key.pem");
@@ -333,6 +341,8 @@ mod test {
     use std::sync::mpsc;
     use std::thread;
 
+    use tempfile::Builder as TempBuilder;
+
     #[test]
     fn test() {
         // just check it does something
@@ -341,7 +351,10 @@ mod test {
 
     #[test]
     fn verify() {
-        let temp_dir = tempdir::TempDir::new("t").unwrap();
+        let temp_dir = TempBuilder::new()
+            .prefix("t")
+            .tempdir()
+            .unwrap();
 
         let keys = gen_keys();
 
@@ -371,7 +384,10 @@ mod test {
     #[test]
     #[ignore] // TODO: hangs on CI
     fn client_server() {
-        let temp_dir = tempdir::TempDir::new("client_server").unwrap();
+        let temp_dir = TempBuilder::new()
+            .prefix("client_server")
+            .tempdir()
+            .unwrap();
 
         let keys = gen_keys();
 

--- a/test-cert-gen/src/lib.rs
+++ b/test-cert-gen/src/lib.rs
@@ -351,10 +351,7 @@ mod test {
 
     #[test]
     fn verify() {
-        let temp_dir = TempBuilder::new()
-            .prefix("t")
-            .tempdir()
-            .unwrap();
+        let temp_dir = TempBuilder::new().prefix("t").tempdir().unwrap();
 
         let keys = gen_keys();
 


### PR DESCRIPTION
the latter is no longer maintained. When using [`cargo-audit`](https://crates.io/crates/cargo-audit), it causes [this advisory](https://rustsec.org/advisories/RUSTSEC-2018-0017) to appear for downstream crates.