### PR TITLE
Remove unused dependencies from tls-api

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,11 +16,8 @@ bench = false
 travis-ci = { repository = "https://github.com/stepancheg/rust-tls-api/", branch = "master" }
 
 [dependencies]
-log        = "0.4"
 pem        = "0.8.3"
-webpki     = "0.22.0"
 tempfile   = "3.3.0"
-void       = "1.0.2"
 anyhow     = "1.0.44"
 thiserror  = "1.0.30"
 


### PR DESCRIPTION
As far as I can tell, these dependencies are not used in the crate and can be safely removed.

The webpki dependency in particular was identified as potential problem for Arti, the Rust re-implementation of Tor: <https://gitlab.torproject.org/tpo/core/arti/-/issues/509>.

